### PR TITLE
Make the executable named `asfmd`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Small Python tool (`asfsmd`) that allows to download XML files containing
 Sentinel-1 products metadata from the ASF archive.
 
 Sentinel-1 products are stored in the ASF arcive as ZIP files that are
-quite large because they comntain both the products annotations and the
+quite large because they contain both the products annotations and the
 binary image data.
 
 The `asfsmd` tool is able to retrieve only the relatively samll annotation

--- a/asfsmd.py
+++ b/asfsmd.py
@@ -42,7 +42,7 @@ __all__ = ["download_annotations", "main"]
 _log = logging.getLogger(__name__)
 
 
-BLOACKSIZE = 1 * 1024  # 1kb
+BLOCKSIZE = 1 * 1024  # 1kb
 
 
 class HttpIOFile(httpio.SyncHTTPIOFile):
@@ -77,7 +77,7 @@ def query(products, auth=None):
 
 
 def download_annotations_core(urls, outdir=".", auth=None,
-                              block_size=BLOACKSIZE):
+                              block_size=BLOCKSIZE):
     """Download Sentinel-1 annotationd for the specified product urls."""
     outdir = pathlib.Path(outdir)
 
@@ -287,7 +287,7 @@ def _get_parser(subparsers=None):
     parser.add_argument(
         "--block-size",
         type=int,
-        default=BLOACKSIZE,
+        default=BLOCKSIZE,
         help="httpio block size in bytes (default: %(default)d)",
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    asfmd = asfsmd:main
+    asfsmd = asfsmd:main
 
 [options.extras_require]
 cli =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    executable-name = asfsmd:main
+    asfmd = asfsmd:main
 
 [options.extras_require]
 cli =


### PR DESCRIPTION
rather than `executable-name`