### PR TITLE
Add filter for polarization and additional calibration/noise/rfi downloads

### DIFF
--- a/asfsmd.py
+++ b/asfsmd.py
@@ -67,7 +67,7 @@ class HttpIOFile(httpio.SyncHTTPIOFile):
         return self
 
 
-def query(products, auth=None):
+def query(products):
     """Query the specified Sentinel-1 products."""
     if isinstance(products, str):
         products = [products]
@@ -136,7 +136,7 @@ def download_annotations_core(urls, outdir=".", auth=None,
 
 def download_annotations(products, outdir=".", auth=None, pol=None):
     """Download annotationd for the specified Sentinel-1 products."""
-    results = query(products, auth=auth)
+    results = query(products)
     if len(results) != len(products):
         warnings.warn(
             f"only {len(results)} of the {len(products)} requested products "

--- a/asfsmd.py
+++ b/asfsmd.py
@@ -110,7 +110,6 @@ def download_annotations_core(urls, outdir=".", auth=None,
                     for info in zf.filelist:
                         for pattern, filter in patterns.items():
                             if fnmatch.fnmatch(info.filename, pattern):
-                                # TODO: cleaner vers
                                 if filter in info.filename:
                                     components.append(info)
                                     break

--- a/asfsmd.py
+++ b/asfsmd.py
@@ -307,27 +307,29 @@ def _get_parser(subparsers=None):
     )
     # Optional filters
     parser.add_argument(
-        "--pol",
         "--polarization",
         choices=["vv", "vh"],
         type=str.lower,
         help="Choose only one polarization to download. "
         "If not provided both polarizations are downloaded."
-    ) 
+    )
 
     # Additional file downloads
     parser.add_argument(
-        "--do-calibration",
+        "-c",
+        "--calibration",
         action="store_true",
         help="Download calibration files."
     )
     parser.add_argument(
-        "--do-noise",
+        "-n",
+        "--noise",
         action="store_true",
         help="Download noise calibration files."
     )
     parser.add_argument(
-        "--do-rfi",
+        "-r",
+        "--rfi",
         action="store_true",
         help="Download RFI files."
     )

--- a/asfsmd.py
+++ b/asfsmd.py
@@ -314,7 +314,7 @@ def _get_parser(subparsers=None):
     # Optional filters
     parser.add_argument(
         "--polarization",
-        choices=["vv", "vh"],
+        choices=["vv", "vh", "hv", "hh"],
         type=str.lower,
         help="Choose only one polarization to download. "
         "If not provided both polarizations are downloaded."


### PR DESCRIPTION
This adds two functions:
1. Filter the download by polarization (e.g. so you can grab only 3 'vv' files instead of the 6 for vv/vh)
2. Download the calibration, noise, and RFI xml files 
 
I also made a separate branch to further filter to a single subswath by checking `iw{number}`, but these are the additions I've already found useful when testing https://github.com/opera-adt/s1-reader